### PR TITLE
bump: v0.1.0-rc.39

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -13,5 +13,5 @@ inputs:
     default: 'false'
 runs:
   using: docker
-  image: docker://ghcr.io/akuity/kargo-render:v0.1.0-rc.37
+  image: docker://ghcr.io/akuity/kargo-render:v0.1.0-rc.39
   args: action

--- a/action.yaml
+++ b/action.yaml
@@ -14,5 +14,4 @@ inputs:
 runs:
   using: docker
   image: docker://ghcr.io/akuity/kargo-render:v0.1.0-rc.39
-  args:
-  - action
+  args: action

--- a/action.yaml
+++ b/action.yaml
@@ -14,4 +14,5 @@ inputs:
 runs:
   using: docker
   image: docker://ghcr.io/akuity/kargo-render:v0.1.0-rc.39
-  args: action
+  args:
+  - action


### PR DESCRIPTION
This bumps Kargo Render to the most current version. We also set `args` as an array, since it seems like GH Actions has changed something on that front.